### PR TITLE
Reassign CustomModelData for Magic in a Bottle

### DIFF
--- a/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/cauldron/extra_items/catch_possessed_items.mcfunction
+++ b/gm4_zauber_cauldrons/data/zauber_cauldrons/functions/cauldron/extra_items/catch_possessed_items.mcfunction
@@ -3,7 +3,7 @@
 #at allign xyz
 
 #summon bottle and remove one from fullness (bottle is used to be bottled into)
-summon item ~ ~.2 ~ {Item:{id:"minecraft:glass_bottle",Count:1b,tag:{CustomModelData:2,gm4_zauber_cauldrons:{item:"bottled_vex"},Enchantments:[{id:"minecraft:protection",lvl:0s}],display:{Name:'{"translate":"%1$s","with":["Magic in a Bottle",{"translate":"item.gm4.magic_in_a_bottle"}],"italic":false}'},HideFlags:1}}}
+summon item ~ ~.2 ~ {Item:{id:"minecraft:glass_bottle",Count:1b,tag:{CustomModelData:3,gm4_zauber_cauldrons:{item:"bottled_vex"},Enchantments:[{id:"minecraft:protection",lvl:0s}],display:{Name:'{"translate":"%1$s","with":["Magic in a Bottle",{"translate":"item.gm4.magic_in_a_bottle"}],"italic":false}'},HideFlags:1}}}
 
 #store amount of excess items in item nbt
 execute store result entity @e[type=item,dx=0,dy=0,dz=0,nbt={Item:{tag:{gm4_zauber_cauldrons:{item:"bottled_vex"}}}},limit=1] Item.tag.gm4_zauber_cauldrons.vex_count int 1 run scoreboard players get @s gm4_zc_fullness


### PR DESCRIPTION
This commit reassigns the CustomModelData for Magic in a Bottle from 2
to 3, to give room for Sunken Treasure to have an advancement icon with
CustomModelData 2. This is required for consistency purposes, as every
other module with both an advancement icon and a custom item using the
same item ID has sequential CustomModelData.